### PR TITLE
chore(deps): bump rust toolchain to version nightly-2022-05-05

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-07-19"
+channel = "nightly-2023-01-26"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
 profile = "minimal"
 components = ["rustfmt", "clippy", "miri", "rust-src"]


### PR DESCRIPTION
chore(deps): bump rust toolchain to version nightly-2022-05-05